### PR TITLE
Fix build with gcc-9 arm-linux-gnueabi toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ OBJCOPY		= $(CROSS_COMPILE)objcopy
 CFLAGS		= -Os -g -mcpu=cortex-a9
 ASFLAGS		= $(CFLAGS) -Wa,-mcpu=cortex-a9+mp
 LDSCRIPT	= bootrom.ld
-LDFLAGS		= -nostdlib -T $(LDSCRIPT)
+LDFLAGS		= -Wl,--build-id=none -static -nostdlib -T $(LDSCRIPT)
 
 OBJS		:= start.o image.o
 


### PR DESCRIPTION
Linux toolchains link dynamically by default, so pass -static.

gcc also adds a .note.gnu.build-id to the beginning of the file, which
messes up our reset vector when converting to a raw binary file. Passing
--build-id=none to the linker gets rid of it.

Signed-off-by: Havard Skinnemoen <hskinnemoen@google.com>
Change-Id: If64eb0fe7298480d5a9c04730088d74b32bcb082