### PR TITLE
ast27x0: Show build date and git version

### DIFF
--- a/ast27x0/Makefile
+++ b/ast27x0/Makefile
@@ -19,6 +19,8 @@ CC		?= $(CROSS_COMPILE)gcc
 OBJCOPY		?= $(CROSS_COMPILE)objcopy
 OBJDUMP		?= $(CROSS_COMPILE)objdump
 
+GIT_VERSION := git-$(shell git rev-parse --short HEAD)
+
 # Why we use -no-pie -fno-pic in bare-metal builds:
 #
 # By default, modern GCC compilers enable PIE (Position-Independent Executable)
@@ -39,6 +41,7 @@ OBJDUMP		?= $(CROSS_COMPILE)objdump
 CFLAGS		= -Os -Wall -Wextra -g -mcpu=cortex-a35 -fno-stack-protector \
 		  -no-pie -fno-pic \
 		  -I ./include -I ../lib/libfdt -I ../lib/libc/minimal/include
+CFLAGS      += -DGIT_VERSION=\"$(GIT_VERSION)\"
 ASFLAGS		= $(CFLAGS) -Wa,-mcpu=cortex-a35
 LDSCRIPT	= bootrom.ld
 MAPFILE		= bootrom.map

--- a/ast27x0/image.c
+++ b/ast27x0/image.c
@@ -61,9 +61,15 @@ static const char *splash_screen =
       "| | / / __  / / / / / / / / / / /_/ / / / / /|_/ /_____/ /| | \\__ \\ / /  __/ /  / /|   / / / /\n"
       "| |/ / /_/ / /_/ / /_/ / / / / _, _/ /_/ / /  / /_____/ ___ |___/ // /  / __/  / //   / /_/ /\n"
       "|___/_____/\\____/\\____/ /_/ /_/ |_|\\____/_/  /_/     /_/  |_/____//_/  /____/ /_//_/|_\\____/\n"
-      "\n"
-      "Version:1.0.0\n"
       "\n";
+
+static void print_build_info()
+{
+   uprintf("%s", splash_screen);
+   uprintf("Build Date : %s %s\n", __DATE__, __TIME__);
+   uprintf("FW Version : %s\n", GIT_VERSION);
+   uprintf("\n");
+}
 
 /*
  * Remap 32-bit BootMCU load address to 64-bit Cortex-A35 DRAM address.
@@ -369,8 +375,7 @@ uint64_t load_boot_image(void)
     uart_aspeed_init(UART12);
     uart_console_register(&ucons);
 
-    uprintf("%s", splash_screen);
-
+    print_build_info();
     fit_blob = find_fit_image(FIT_SEARCH_START,
                               FIT_SEARCH_END,
                               FIT_SEARCH_STEP);


### PR DESCRIPTION
Add print_build_info() to display build date, time, and GIT_VERSION. GIT_VERSION is passed via Makefile using git-<commit> format. Build date and time are injected via __DATE__ and __TIME__ macros.

```
Build Date : Apr 25 2025 02:11:30
FW Version : git-82bed5c
```