### PR TITLE
ast27x0: Fix missing SCU module reset for SSP and TSP initialization

### DIFF
--- a/ast27x0/include/ssp_tsp.h
+++ b/ast27x0/include/ssp_tsp.h
@@ -31,6 +31,8 @@
 
 /* SCU */
 #define ASPEED_CPU_SCU_BASE 0x12C02000
+#define SCU_CPU_RST_SSP     BIT(30)
+#define SCU_CPU_RST2_TSP    BIT(9)
 
 struct ast2700_scu0 {
     uint32_t rsv_0x11c[72];     /* 0x000 ~ 0x11C */
@@ -58,6 +60,16 @@ struct ast2700_scu0 {
     uint32_t tsp_ctrl_5;        /* 0x178 */
     uint32_t rsv_0x17c[6];      /* 0x17C ~ 0x190 */
     uint32_t tsp_remap_size;    /* 0x194 */
+    uint32_t rsv_0x198[26];     /* 0x198 ~ 0x1FC */
+    uint32_t modrst1_ctrl;      /* 0x200 */
+    uint32_t modrst1_clr;       /* 0x204 */
+    uint32_t rsv_0x208[2];      /* 0x208 ~ 0x20C */
+    uint32_t modrst1_lock;      /* 0x210 */
+    uint32_t modrst1_prot1;     /* 0x214 */
+    uint32_t modrst1_prot2;     /* 0x218 */
+    uint32_t modrst1_prot3;     /* 0x21C */
+    uint32_t modrst2_ctrl;      /* 0x220 */
+    uint32_t modrst2_clr;       /* 0x224 */
 };
 
 /* SSP control register 0 */

--- a/ast27x0/ssp_tsp.c
+++ b/ast27x0/ssp_tsp.c
@@ -77,6 +77,9 @@ int ssp_init(uint64_t load_addr, const struct reserved_mem_info *info)
         return 0;
     }
 
+    writel(SCU_CPU_RST_SSP, (void *)&scu->modrst1_ctrl);
+    writel(SCU_CPU_RST_SSP, (void *)&scu->modrst1_clr);
+
     reg_val = SCU_CPU_SSP_TSP_NIDEN | SCU_CPU_SSP_TSP_DBGEN |
               SCU_CPU_SSP_TSP_DBG_ENABLE | SCU_CPU_SSP_TSP_RESET;
     writel(reg_val, (void *)&scu->ssp_ctrl_0);
@@ -154,6 +157,9 @@ int tsp_init(uint64_t load_addr, const struct reserved_mem_info *info)
     if (!(reg_val & SCU_CPU_SSP_TSP_RESET_STS)) {
         return 0;
     }
+
+    writel(SCU_CPU_RST2_TSP, (void *)&scu->modrst2_ctrl);
+    writel(SCU_CPU_RST2_TSP, (void *)&scu->modrst2_clr);
 
     reg_val = SCU_CPU_SSP_TSP_NIDEN | SCU_CPU_SSP_TSP_DBGEN |
               SCU_CPU_SSP_TSP_DBG_ENABLE | SCU_CPU_SSP_TSP_RESET;


### PR DESCRIPTION
Fix SSP and TSP boot failure caused by missing SCU reset control. This commit adds SCU modrst1/modrst2 reset logic to ssp_init() and tsp_init(). Without proper reset release, SSP and TSP CPUs stay in reset and cannot start. Also adds missing SCU register fields and reset bit definitions for SSP (BIT(30)) and TSP (BIT(9)).

Fixes: 80768e4 ("ast27x0: Initialize and enable SSP/TSP using SCU with reserved- memory from DTB")