### PR TITLE
ast27x0: Fix Makefile to unconditionally set CC to support correct cross-compilation

### DIFF
--- a/ast27x0/Makefile
+++ b/ast27x0/Makefile
@@ -15,9 +15,9 @@
 
 CROSS_COMPILE	?= aarch64-linux-gnu-
 
-CC		?= $(CROSS_COMPILE)gcc
-OBJCOPY		?= $(CROSS_COMPILE)objcopy
-OBJDUMP		?= $(CROSS_COMPILE)objdump
+CC		= $(CROSS_COMPILE)gcc
+OBJCOPY		= $(CROSS_COMPILE)objcopy
+OBJDUMP		= $(CROSS_COMPILE)objdump
 
 GIT_VERSION := git-$(shell git rev-parse --short HEAD)
 


### PR DESCRIPTION
The Makefile previously used CC ?= $(CROSS_COMPILE)gcc, but this is ineffective because make always sets the CC variable by default. As a result, the intended default for CC was ignored and cross-compilation could silently fail or misbehave.

This patch removes the conditional assignment operator ?= for CC, OBJCOPY, and OBJDUMP, making them unconditionally defined from the CROSS_COMPILE prefix as done in other vbootrom subdirectories. This simplifies usage and makes the build work without requiring users to manually specify CC on the command line.

Now users can simply run make without needing to export or override variables.