### PR TITLE
ast27x0: Fix compilation issues on Ubuntu 22.04

### DIFF
--- a/ast27x0/ast_loader.c
+++ b/ast27x0/ast_loader.c
@@ -54,7 +54,7 @@ uint32_t calc_checksum(const uint8_t *data, size_t length)
     return crc ^ FINAL_XOR;
 }
 
-int ast_loader_read(uint64_t *dst, uint64_t src, uint32_t len)
+int ast_loader_read(void *dst, uint64_t src, uint32_t len)
 {
     uprintf("%s: dst=0x%lx, src=0x%lx, len=%d\n",
             __func__, dst, src, len);

--- a/ast27x0/include/ast_loader.h
+++ b/ast27x0/include/ast_loader.h
@@ -22,7 +22,7 @@
 void generate_crc32_table(void);
 uint32_t calc_checksum(const uint8_t *data, size_t length);
 
-int ast_loader_read(uint64_t *dst, uint64_t src, uint32_t len);
+int ast_loader_read(void *dst, uint64_t src, uint32_t len);
 int ast_loader_load_image(uint32_t type, uint32_t *dst);
 int ast_loader_load_manifest_image(uint32_t type, uint32_t *dst);
 

--- a/ast27x0/include/manifest.h
+++ b/ast27x0/include/manifest.h
@@ -18,6 +18,7 @@
 #define __AST27X0_INCLUDE_MANIFEST_H__
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <image.h>
 
 #define CPTRA_FLASH_IMG_MAGIC (0x48534C46) /* 'FLSH' in little endian */

--- a/ast27x0/manifest.c
+++ b/ast27x0/manifest.c
@@ -48,7 +48,7 @@ static int cptra_read_header(struct cptra_image_context *ctx)
     static struct cptra_manifest_hdr hdr = { 0 };
 
     /* Read the manfiest header */
-    ret = ast_loader_read((uint64_t *)&hdr, ctx->manifest_base,
+    ret = ast_loader_read(&hdr, ctx->manifest_base,
                           sizeof(struct cptra_manifest_hdr));
     if (ret) {
         uprintf("Failed to read manifest header.\n");
@@ -88,7 +88,7 @@ static int cptra_read_chk_img_info(struct cptra_image_context *ctx)
 
     size = sizeof(struct cptra_checksum_info);
     size += sizeof(struct cptra_image_info) * img_num;
-    ret = ast_loader_read((uint64_t *)chk_img, ctx->manifest_base + ofst,
+    ret = ast_loader_read(chk_img, ctx->manifest_base + ofst,
                           size);
     if (ret) {
         return CPTRA_ERR_READ_IMG_INFO;


### PR DESCRIPTION
Add missing stdbool.h include and update ast_loader_read() to accept a void * destination buffer to avoid unaligned access when reading packed manifest structures.